### PR TITLE
Arrow hit limit

### DIFF
--- a/ideas/ideas for feature updates.txt
+++ b/ideas/ideas for feature updates.txt
@@ -43,10 +43,6 @@ Allow clients to add a port number to the end of the ip with ":". for example: 1
 
 ----
 
-make arrows go away after hitting a certain number of enemies, or dealing a certain amount of damage
-
-----
-
 make creeper holes like TNT, just only one block. Though I should still have the thing where it hurts entities based on distance.
 
 ----

--- a/src/minicraft/entity/Arrow.java
+++ b/src/minicraft/entity/Arrow.java
@@ -67,10 +67,9 @@ public class Arrow extends Entity implements ClientTickable {
 			
 			if (hit != null && hit instanceof Mob && hit != owner) {
 				Mob mob = (Mob) hit;
-				mobsHit++;
 				int extradamage = (hit instanceof Player ? 0 : 3) + (criticalHit ? 0 : 1);
-				mob.hurt(owner, damage / (3 * (mobsHit - 1) + 1) + extradamage, dir);
-				if (mobsHit > 1) {
+				if (mob.hurt(owner, damage / (2 * mobsHit + 1) + extradamage, dir)) mobsHit++;
+				if (mobsHit > 3) {
 					this.remove();
 				}
 			}

--- a/src/minicraft/entity/Arrow.java
+++ b/src/minicraft/entity/Arrow.java
@@ -13,6 +13,7 @@ public class Arrow extends Entity implements ClientTickable {
 	private int damage;
 	public Mob owner;
 	private int speed;
+	private int mobsHit;
 	
 	public Arrow(Mob owner, Direction dir, int dmg) {
 		this(owner, owner.x, owner.y, dir, dmg);
@@ -30,6 +31,8 @@ public class Arrow extends Entity implements ClientTickable {
 		if (damage > 3) speed = 8;
 		else if (damage >= 0) speed = 7;
 		else speed = 6;
+
+		mobsHit = 0;
 		
 		/* // maybe this was a "critical arrow" system or something?
 		if (flag) {
@@ -66,6 +69,10 @@ public class Arrow extends Entity implements ClientTickable {
 				Mob mob = (Mob) hit;
 				int extradamage = (hit instanceof Player ? 0 : 3) + (criticalHit ? 0 : 1);
 				mob.hurt(owner, damage + extradamage, dir);
+				mobsHit++;
+				if (mobsHit > 1) {
+					this.remove();
+				}
 			}
 			
 			// if(owner instanceof Player && Game.isMode("creative") && Game.debug) {

--- a/src/minicraft/entity/Arrow.java
+++ b/src/minicraft/entity/Arrow.java
@@ -67,9 +67,9 @@ public class Arrow extends Entity implements ClientTickable {
 			
 			if (hit != null && hit instanceof Mob && hit != owner) {
 				Mob mob = (Mob) hit;
-				int extradamage = (hit instanceof Player ? 0 : 3) + (criticalHit ? 0 : 1);
-				mob.hurt(owner, damage + extradamage, dir);
 				mobsHit++;
+				int extradamage = (hit instanceof Player ? 0 : 3) + (criticalHit ? 0 : 1);
+				mob.hurt(owner, damage / (3 * (mobsHit - 1) + 1) + extradamage, dir);
 				if (mobsHit > 1) {
 					this.remove();
 				}

--- a/src/minicraft/entity/mob/AirWizard.java
+++ b/src/minicraft/entity/mob/AirWizard.java
@@ -119,11 +119,11 @@ public class AirWizard extends EnemyMob {
 	}
 	
 	@Override
-	public void doHurt(int damage, Direction attackDir) {
-		super.doHurt(damage, attackDir);
+	public boolean doHurt(int damage, Direction attackDir) {
 		if (attackDelay == 0 && attackTime == 0) {
 			attackDelay = 60 * 2;
 		}
+		return super.doHurt(damage, attackDir);
 	}
 	
 	@Override

--- a/src/minicraft/entity/mob/Mob.java
+++ b/src/minicraft/entity/mob/Mob.java
@@ -174,23 +174,24 @@ public abstract class Mob extends Entity {
 			doHurt(damage, tile.mayPass(level, x, y, this) ? Direction.NONE : attackDir); // Call the method that actually performs damage, and set it to no particular direction
 	}
 	
-	public void hurt(Mob mob, int damage) { hurt(mob, damage, getAttackDir(mob, this)); }
-	public void hurt(Mob mob, int damage, Direction attackDir) { // Hurt the mob, when the source is another mob
-		if(mob instanceof Player && Game.isMode("creative") && mob != this) doHurt(health, attackDir); // kill the mob instantly
-		else doHurt(damage, attackDir); // Call the method that actually performs damage, and use our provided attackDir
+	public boolean hurt(Mob mob, int damage) { return hurt(mob, damage, getAttackDir(mob, this)); }
+	public boolean hurt(Mob mob, int damage, Direction attackDir) { // Hurt the mob, when the source is another mob
+		if(mob instanceof Player && Game.isMode("creative") && mob != this) return doHurt(health, attackDir); // kill the mob instantly
+		else return doHurt(damage, attackDir); // Call the method that actually performs damage, and use our provided attackDir
 	}
 	
 	public void hurt(Tnt tnt, int dmg) { doHurt(dmg, getAttackDir(tnt, this)); }
 	
-	protected void doHurt(int damage, Direction attackDir) { // Actually hurt the mob, based on only damage and a direction
+	protected boolean doHurt(int damage, Direction attackDir) { // Actually hurt the mob, based on only damage and a direction
 		// this is overridden in Player.java
-		if (isRemoved() || hurtTime > 0) return; // If the mob has been hurt recently and hasn't cooled down, don't continue
+		if (isRemoved() || hurtTime > 0) return false; // If the mob has been hurt recently and hasn't cooled down, don't continue
 		
 		health -= damage; // Actually change the health
 		// add the knockback in the correct direction
 		xKnockback = attackDir.getX()*6;
 		yKnockback = attackDir.getY()*6;
 		hurtTime = 10; // Set a delay before we can be hurt again
+		return true;
 	}
 	
 	/**

--- a/src/minicraft/entity/mob/MobAi.java
+++ b/src/minicraft/entity/mob/MobAi.java
@@ -109,8 +109,8 @@ public abstract class MobAi extends Mob {
 	}
 	
 	@Override
-	public void doHurt(int damage, Direction attackDir) {
-		if (isRemoved() || hurtTime > 0) return; // If the mob has been hurt recently and hasn't cooled down, don't continue
+	public boolean doHurt(int damage, Direction attackDir) {
+		if (isRemoved() || hurtTime > 0) return false; // If the mob has been hurt recently and hasn't cooled down, don't continue
 		
 		Player player = getClosestPlayer();
 		if (player != null) { // If there is a player in the level
@@ -123,7 +123,7 @@ public abstract class MobAi extends Mob {
 		}
 		level.add(new TextParticle("" + damage, x, y, Color.RED)); // Make a text particle at this position in this level, bright red and displaying the damage inflicted
 		
-		super.doHurt(damage, attackDir);
+		return super.doHurt(damage, attackDir);
 	}
 	
 	@Override

--- a/src/minicraft/entity/mob/Player.java
+++ b/src/minicraft/entity/mob/Player.java
@@ -904,13 +904,16 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 	
 	/** What happens when the player is hurt */
 	@Override
-	protected void doHurt(int damage, Direction attackDir) {
-		if (Game.isMode("creative") || hurtTime > 0 || Bed.inBed(this)) return; // can't get hurt in creative, hurt cooldown, or while someone is in bed
-		
+	protected boolean doHurt(int damage, Direction attackDir) {
+		if (Game.isMode("creative") || hurtTime > 0 || Bed.inBed(this)) return false; // can't get hurt in creative, hurt cooldown, or while someone is in bed
+
+		boolean washurt = false;
+
 		if(Game.isValidServer() && this instanceof RemotePlayer) {
 			// let the clients deal with it.
 			Game.server.broadcastPlayerHurt(eid, damage, attackDir);
-			return;
+			// TODO: really should do something proper here, but I don't know how and we don't need the return for this
+			return false;
 		}
 		
 		boolean fullPlayer = !(Game.isValidClient() && this != Game.player);
@@ -947,10 +950,11 @@ public class Player extends Mob implements ItemHolder, ClientTickable {
 		
 		if(healthDam > 0 || !fullPlayer) {
 			level.add(new TextParticle("" + damage, x, y, Color.get(-1, 504)));
-			if(fullPlayer) super.doHurt(healthDam, attackDir); // sets knockback, and takes away health.
+			if(fullPlayer) washurt = super.doHurt(healthDam, attackDir); // sets knockback, and takes away health.
 		}
 		
 		hurtTime = playerHurtTime;
+		return washurt;
 	}
 	
 	@Override


### PR DESCRIPTION
Adds a limit to the number of entities an arrow can hit before disappearing. Also reduces the damage for hits after the first.