### PR TITLE
Revert FPS setting

### DIFF
--- a/src/minicraft/core/io/Settings.java
+++ b/src/minicraft/core/io/Settings.java
@@ -12,7 +12,7 @@ public class Settings {
 	private static HashMap<String, ArrayEntry> options = new HashMap<>();
 	
 	static {
-		options.put("fps", new RangeEntry("Max FPS", 10, 300, GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDisplayMode().getRefreshRate()));
+		options.put("fps", new RangeEntry("Max FPS", 10, 300, 60));
 		options.put("diff", new ArrayEntry<>("Difficulty", "Easy", "Normal", "Hard"));
 		options.get("diff").setSelection(1);
 		options.put("mode", new ArrayEntry<>("Game Mode", "Survival", "Creative", "Hardcore", "Score"));


### PR DESCRIPTION
The call to getDefaultScreenDevice() throws an exception if there is no screen (e.g. when starting a server in a headless environment).
Additionally the getRefreshRate() can return 0, which should be handled properly.

https://docs.oracle.com/javase/7/docs/api/java/awt/DisplayMode.html#getRefreshRate()