### PR TITLE
Add item "Natural rock" in creative mode

### DIFF
--- a/src/minicraft/item/TileItem.java
+++ b/src/minicraft/item/TileItem.java
@@ -23,6 +23,7 @@ public class TileItem extends StackableItem {
 		items.add(new TileItem("Flower", (new Sprite(4, 0, 0)), "flower", "grass"));
 		items.add(new TileItem("Acorn", (new Sprite(7, 3, 0)), "tree Sapling", "grass"));
 		items.add(new TileItem("Dirt", (new Sprite(0, 0, 0)), "dirt", "hole", "water", "lava"));
+		items.add(new TileItem("Natural Rock", (new Sprite(2, 0, 0)), "rock", "hole", "dirt", "sand", "grass", "path", "water", "lava"));
 		
 		items.add(new TileItem("Plank", (new Sprite(0, 5, 0)), "Wood Planks", "hole", "water", "cloud"));
 		items.add(new TileItem("Plank Wall", (new Sprite(1, 5, 0)), "Wood Wall", "Wood Planks"));

--- a/src/resources/localization/english_en-us.mcpl
+++ b/src/resources/localization/english_en-us.mcpl
@@ -521,6 +521,9 @@ Grass
 Dirt
 Dirt
 
+Natural Rock
+Natural Rock
+
 Flower
 Flower
 

--- a/src/resources/localization/french_fr-fr.mcpl
+++ b/src/resources/localization/french_fr-fr.mcpl
@@ -348,6 +348,9 @@ Gland
 Dirt
 Terre
 
+Natural Rock
+Roche naturelle
+
 Plank
 Planche
 

--- a/src/resources/localization/italiano_it-it.mcpl
+++ b/src/resources/localization/italiano_it-it.mcpl
@@ -349,6 +349,9 @@ Ghianda
 Dirt
 Terra
 
+Natural Rock
+Roccia naturalev
+
 Plank
 Asse
 

--- a/src/resources/localization/norwegian_nb-no.mcpl
+++ b/src/resources/localization/norwegian_nb-no.mcpl
@@ -364,6 +364,9 @@ Eikenøtt
 Dirt
 Jord
 
+Natural Rock
+Naturlig stein
+
 Plank
 Planke
 

--- a/src/resources/localization/spanish_es-es.mcpl
+++ b/src/resources/localization/spanish_es-es.mcpl
@@ -350,6 +350,9 @@ Bellota
 Dirt
 Tierra
 
+Natural Rock
+Roca natural
+
 Plank
 Tablón
 


### PR DESCRIPTION
User can add rock, it is useful as once rock is broken in creative mode, there is no way to regenerate it.