### PR TITLE
Add Inventory Searcher Bar

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -9,6 +9,7 @@ Minicraft+ version 2.0.7
 + Added SRV record support; service name is _minicraft
 + Added aggregate analytics for various game states and actions
 + Added Fullscreen Mode [ default key F11 ]
++ Added Inventory Searcher Bar [ default keys Shift+T to toggle and Next/Back Page to seek ]
 * Sparks (the airwizard bullets) have been optimised
 * Fixed picked up dungeon chests
 * Tiles now connect to the edge of the world

--- a/src/minicraft/core/io/InputHandler.java
+++ b/src/minicraft/core/io/InputHandler.java
@@ -112,6 +112,13 @@ public class InputHandler implements KeyListener {
 		keymap.put("PICKUP", "V|P"); // pickup torches / furniture; this replaces the power glove.
 		keymap.put("DROP-ONE", "Q"); // drops the item in your hand, or selected in your inventory, by ones; it won't drop an entire stack
 		keymap.put("DROP-STACK", "SHIFT-Q"); // drops the item in your hand, or selected in your inventory, entirely; even if it's a stack.
+
+		// toggle inventory searcher bar
+		keymap.put("SEARCHER-BAR", "SHIFT-T");
+
+		// seek for next/previous match in inventory searcher bar
+		keymap.put("PAGE-UP", "PAGE_UP");
+		keymap.put("PAGE-DOWN", "PAGE_DOWN");
 		
 		keymap.put("PAUSE", "ESCAPE"); // pause the Game.
 		

--- a/src/minicraft/gfx/Color.java
+++ b/src/minicraft/gfx/Color.java
@@ -36,6 +36,20 @@ public class Color {
 	public static final int YELLOW = Color.get(1, 255, 255, 0);
 	public static final int MAGENTA = Color.get(1, 255, 0, 255);
 	public static final int CYAN = Color.get(1, 0, 255, 255);
+
+	public static final char COLOR_CHAR = '\u00A7';
+
+	public static final String TRANSPARENT_CODE = Color.toStringCode(Color.TRANSPARENT);
+	public static final String WHITE_CODE = Color.toStringCode(Color.WHITE);
+	public static final String GRAY_CODE = Color.toStringCode(Color.GRAY);
+	public static final String DARK_GRAY_CODE = Color.toStringCode(Color.DARK_GRAY);
+	public static final String BLACK_CODE = Color.toStringCode(Color.BLACK);
+	public static final String RED_CODE = Color.toStringCode(Color.RED);
+	public static final String GREEN_CODE = Color.toStringCode(Color.GREEN);
+	public static final String BLUE_CODE = Color.toStringCode(Color.BLUE);
+	public static final String YELLOW_CODE = Color.toStringCode(Color.YELLOW);
+	public static final String MAGENTA_CODE = Color.toStringCode(Color.MAGENTA);
+	public static final String CYAN_CODE = Color.toStringCode(Color.CYAN);
 	
 	/** This returns a minicraftrgb.
 	 * a should be between 0-1, r,g,and b should be 0-255 */
@@ -44,6 +58,22 @@ public class Color {
 	}
 	public static int get(int a, int copy) {
 		return get(a, copy, copy, copy);
+	}
+
+	public static String toStringCode(int color) {
+		return new String(new char[] {
+				Color.COLOR_CHAR,
+				(char) ((color >> 24) & 0xFF), // Alpha
+				(char) ((color >> 16) & 0xFF), // Red
+				(char) ((color >>  8) & 0xFF), // Blue
+				(char) (color         & 0xFF)  // Green
+		});
+	}
+
+	public static int get(String color) {
+		// omit color character if it's present
+		int leading = color.charAt(0) == Color.COLOR_CHAR ? 1 : 0;
+		return Color.get(color.charAt(leading), color.charAt(1 + leading), color.charAt(2 + leading), color.charAt(3 + leading));
 	}
 	
 	private static int limit(int num, int min, int max) {

--- a/src/minicraft/gfx/Color.java
+++ b/src/minicraft/gfx/Color.java
@@ -72,7 +72,7 @@ public class Color {
 
 	public static int get(String color) {
 		// omit color character if it's present
-		int leading = color.charAt(0) == Color.COLOR_CHAR ? 1 : 0;
+		int leading = color.length() == 5 ? 1 : 0;
 		return Color.get(color.charAt(leading), color.charAt(1 + leading), color.charAt(2 + leading), color.charAt(3 + leading));
 	}
 	

--- a/src/minicraft/gfx/Font.java
+++ b/src/minicraft/gfx/Font.java
@@ -29,6 +29,35 @@ public class Font {
 		}
 	}
 
+	public static void drawColor(String message, Screen screen, int x, int y) {
+		// set default color message if it doesn't have initially
+		if (message.charAt(0) != Color.COLOR_CHAR) {
+			message = Color.WHITE_CODE + message;
+		}
+
+		int leading = 0;
+		for (String data : message.split(String.valueOf(Color.COLOR_CHAR))) {
+			if (data.isEmpty()) {
+				continue;
+			}
+
+			String text;
+			String color;
+
+			try {
+				text = data.substring(4);
+				color = data.substring(0, 4); // ARGB value
+			} catch (IndexOutOfBoundsException ignored) {
+				// bad formatted colored string
+				text = data;
+				color = Color.WHITE_CODE;
+			}
+
+			Font.draw(text, screen, x + leading, y, Color.get(color));
+			leading += Font.textWidth(text);
+		}
+	}
+
 	public static void drawBackground(String msg, Screen screen, int x, int y) { drawBackground(msg, screen, x, y, -1); }
 
 	public static void drawBackground(String msg, Screen screen, int x, int y, int whiteTint) {

--- a/src/minicraft/screen/InventoryMenu.java
+++ b/src/minicraft/screen/InventoryMenu.java
@@ -15,20 +15,16 @@ class InventoryMenu extends ItemListMenu {
 	private Entity holder;
 	
 	InventoryMenu(Entity holder, Inventory inv, String title) {
-		super(InventoryMenu.getBuilder(), ItemEntry.useItems(inv.getItems()), title);
+		super(ItemListMenu.getBuilder(), ItemEntry.useItems(inv.getItems()), title);
 		this.inv = inv;
 		this.holder = holder;
 	}
 	
 	InventoryMenu(InventoryMenu model) {
-		super(InventoryMenu.getBuilder(), ItemEntry.useItems(model.inv.getItems()), model.getTitle());
+		super(ItemListMenu.getBuilder(), ItemEntry.useItems(model.inv.getItems()), model.getTitle());
 		this.inv = model.inv;
 		this.holder = model.holder;
 		setSelection(model.getSelection());
-	}
-
-	static Builder getBuilder() {
-		return ItemListMenu.getBuilder().setSearcherBar(true);
 	}
 	
 	@Override

--- a/src/minicraft/screen/InventoryMenu.java
+++ b/src/minicraft/screen/InventoryMenu.java
@@ -15,16 +15,20 @@ class InventoryMenu extends ItemListMenu {
 	private Entity holder;
 	
 	InventoryMenu(Entity holder, Inventory inv, String title) {
-		super(ItemEntry.useItems(inv.getItems()), title);
+		super(InventoryMenu.getBuilder(), ItemEntry.useItems(inv.getItems()), title);
 		this.inv = inv;
 		this.holder = holder;
 	}
 	
 	InventoryMenu(InventoryMenu model) {
-		super(ItemEntry.useItems(model.inv.getItems()), model.getTitle());
+		super(InventoryMenu.getBuilder(), ItemEntry.useItems(model.inv.getItems()), model.getTitle());
 		this.inv = model.inv;
 		this.holder = model.holder;
 		setSelection(model.getSelection());
+	}
+
+	static Builder getBuilder() {
+		return ItemListMenu.getBuilder().setSearcherBar(true);
 	}
 	
 	@Override

--- a/src/minicraft/screen/ItemListMenu.java
+++ b/src/minicraft/screen/ItemListMenu.java
@@ -10,7 +10,8 @@ class ItemListMenu extends Menu {
 			.setPositioning(new Point(9, 9), RelPos.BOTTOM_RIGHT)
 			.setDisplayLength(9)
 			.setSelectable(true)
-			.setScrollPolicies(1, false);
+			.setScrollPolicies(1, false)
+			.setSearcherBar(true);
 	}
 	
 	ItemListMenu(Builder b, ItemEntry[] entries, String title) {

--- a/src/minicraft/screen/entry/ListEntry.java
+++ b/src/minicraft/screen/entry/ListEntry.java
@@ -5,6 +5,8 @@ import minicraft.gfx.Color;
 import minicraft.gfx.Font;
 import minicraft.gfx.Screen;
 
+import java.util.Locale;
+
 public abstract class ListEntry {
 	
 	public static final int COL_UNSLCT = Color.GRAY;
@@ -17,6 +19,22 @@ public abstract class ListEntry {
 	 * @param input InputHandler used to get player input.
 	 */
 	public abstract void tick(InputHandler input);
+
+	public void render(Screen screen, int x, int y, boolean isSelected, String contain, int containColor) {
+		if (!visible) {
+			return;
+		}
+
+		render(screen, x, y, isSelected);
+		if (contain == null || contain.isEmpty()) {
+			return;
+		}
+
+		String string = toString().toLowerCase(Locale.ENGLISH);
+		contain = contain.toLowerCase(Locale.ENGLISH);
+
+		Font.drawColor(string.replaceAll(contain, Color.toStringCode(containColor) + contain + Color.WHITE_CODE), screen, x, y);
+	}
 	
 	/**
 	 * Renders the entry to the given screen.


### PR DESCRIPTION
This will help you out in look for an item for just typing its name quickly
It's enabled in Workbench, Furnace, Oven, Chest and Player Inventory and any Item List Menu that be added, just if searcher bar is enabled by default otherwise no.

To toggle searcher bar, Shift+T was used plus to seek a next/previous match Next/Back Page button were used, but those may be changed in keys setting