### PR TITLE
Bug fix: arrows were not going through the infiniteFall tile

### DIFF
--- a/src/main/java/minicraft/level/tile/InfiniteFallTile.java
+++ b/src/main/java/minicraft/level/tile/InfiniteFallTile.java
@@ -1,6 +1,7 @@
 package minicraft.level.tile;
 
 import minicraft.core.Game;
+import minicraft.entity.Arrow;
 import minicraft.entity.Entity;
 import minicraft.entity.mob.AirWizard;
 import minicraft.entity.mob.Player;
@@ -19,6 +20,6 @@ public class InfiniteFallTile extends Tile {
 	public boolean tick(Level level, int xt, int yt) { return false; }
 
 	public boolean mayPass(Level level, int x, int y, Entity e) {
-		return e instanceof AirWizard || e instanceof Player && ( ((Player) e).skinon || Game.isMode("creative") );
+		return e instanceof AirWizard || e instanceof Arrow || e instanceof Player && ( ((Player) e).skinon || Game.isMode("creative") );
 	}
 }


### PR DESCRIPTION
The arrows, when a bow was used, could not pass the "InfiniteFall" tile, that is, the arrows were eliminated at the moment of touching said tile.