### PR TITLE
Fix that certain characters crash Inventory Search

### DIFF
--- a/src/main/java/minicraft/screen/entry/ListEntry.java
+++ b/src/main/java/minicraft/screen/entry/ListEntry.java
@@ -33,7 +33,7 @@ public abstract class ListEntry {
 		String string = toString().toLowerCase(Locale.ENGLISH);
 		contain = contain.toLowerCase(Locale.ENGLISH);
 
-		Font.drawColor(string.replaceAll(contain, Color.toStringCode(containColor) + contain + Color.WHITE_CODE), screen, x, y);
+		Font.drawColor(string.replace(contain, Color.toStringCode(containColor) + contain + Color.WHITE_CODE), screen, x, y);
 	}
 	
 	/**


### PR DESCRIPTION
This is because of String#replaceAll uses regex, which it is asking
some regex pattern thereby now it's changed it to String#replace because
it doesn't use regex, avoiding this crash when typing characters like
"{", "[" or "("

This fixes related issue #218
![image](https://user-images.githubusercontent.com/20363359/143788667-32990f7a-df7b-4d4e-99d6-3db6cd7f120a.png)
