### PR TITLE
Fix parent when going back to World Select Display

### DIFF
--- a/src/main/java/minicraft/screen/WorldSelectDisplay.java
+++ b/src/main/java/minicraft/screen/WorldSelectDisplay.java
@@ -110,7 +110,14 @@ public class WorldSelectDisplay extends Display {
 	
 	@Override
 	public void init(Display parent) {
-		super.init(parent);
+		if (parent instanceof WorldEditDisplay && parent.getParent() != null) {
+			// this should get original parent when World Select Display
+			// changed to World Edit Display
+			super.init(parent.getParent().getParent());
+		} else {
+			super.init(parent);
+		}
+
 		worldName = "";
 		loadedWorld = true;
 		


### PR DESCRIPTION
When action is done either copy, rename or delete
this goes from World Select Display to World Edit
Display thereby that minicraft.core.Updater class
set the new parent to new menu that is World Edit
Display, but when it goes from World Edit Display
to World Select Display, minicraft.core.Updater
class initializes it with World Edit Display so
when user tries to exit from menu, it'll go back
again to previous World Edit Display. To avoid
this bug, World Select Display will select parent
correctly when editing process started if given
conditions are true that means that will pick
the select's parent from edit's parent what it'll
result as the initial parent

This fixes related issue #211
also I'm not sure if this might have another good fix for this bug but this is what it reaches first to me