### PR TITLE
 Dungeon chests will no longer appear too deep within obsidian walls.

### DIFF
--- a/src/main/java/minicraft/core/Updater.java
+++ b/src/main/java/minicraft/core/Updater.java
@@ -87,6 +87,14 @@ public class Updater extends Game {
 	// VERY IMPORTANT METHOD!! Makes everything keep happening.
 	// In the end, calls menu.tick() if there's a menu, or level.tick() if no menu.
 	public static void tick() {
+		
+		// move the player for -1, or 1 levels for testing...
+        if (isMode("creative") && input.getKey("MOVE-DOWN").clicked && input.getKey("F3").clicked ) {
+        	Game.setMenu(new LevelTransitionDisplay(-1));
+        } else if (isMode("creative") && input.getKey("MOVE-UP").clicked && input.getKey("F3").clicked ){
+        	Game.setMenu(new LevelTransitionDisplay(1));
+        }
+
 		if (Updater.HAS_GUI && input.getKey("FULLSCREEN").clicked) {
 			Updater.FULLSCREEN = !Updater.FULLSCREEN;
 			Updater.updateFullscreen();

--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -276,14 +276,14 @@ public class Level {
 					boolean xaxis = random.nextBoolean();
 					if (xaxis) {
 						for (int s = x2; s < w - s; s++) {
-							if (getTile(s, y2) == Tiles.get("Obsidian Wall")) {
+							if (getTile(s, y2) == Tiles.get("Obsidian")) {
 								d.x = s * 16 - 24;
 								d.y = y2 * 16 - 24;
 							}
 						}
 					} else { // y axis
 						for (int s = y2; s < y2 - s; s++) {
-							if (getTile(x2, s) == Tiles.get("Obsidian Wall")) {
+							if (getTile(x2, s) == Tiles.get("Obsidian")) {
 								d.x = x2 * 16 - 24;
 								d.y = s * 16 - 24;
 							}
@@ -293,7 +293,7 @@ public class Level {
 						d.x = x2 * 16 - 8;
 						d.y = y2 * 16 - 8;
 					}
-					if (getTile(d.x / 16, d.y / 16) == Tiles.get("Obsidian Wall")) {
+					if (getTile(d.x / 16, d.y / 16) == Tiles.get("Obsidian")) {
 						setTile(d.x / 16, d.y / 16, Tiles.get("Obsidian"));
 					}
 					

--- a/src/main/java/minicraft/level/Level.java
+++ b/src/main/java/minicraft/level/Level.java
@@ -276,16 +276,16 @@ public class Level {
 					boolean xaxis = random.nextBoolean();
 					if (xaxis) {
 						for (int s = x2; s < w - s; s++) {
-							if (getTile(s, y2) == Tiles.get("Obsidian")) {
-								d.x = s * 16 - 24;
-								d.y = y2 * 16 - 24;
+							if (getTile(s, y2) == Tiles.get("Obsidian Wall")) {
+								d.x = s * 20 - 16;
+								d.y = y2 * 24 - 14;
 							}
 						}
 					} else { // y axis
 						for (int s = y2; s < y2 - s; s++) {
-							if (getTile(x2, s) == Tiles.get("Obsidian")) {
-								d.x = x2 * 16 - 24;
-								d.y = s * 16 - 24;
+							if (getTile(x2, s) == Tiles.get("Obsidian Wall")) {
+								d.x = x2 * 23 - 14;
+								d.y = s * 21 - 16;
 							}
 						}
 					}
@@ -293,7 +293,7 @@ public class Level {
 						d.x = x2 * 16 - 8;
 						d.y = y2 * 16 - 8;
 					}
-					if (getTile(d.x / 16, d.y / 16) == Tiles.get("Obsidian")) {
+					if (getTile(d.x / 16, d.y / 16) == Tiles.get("Obsidian Wall")) {
 						setTile(d.x / 16, d.y / 16, Tiles.get("Obsidian"));
 					}
 					


### PR DESCRIPTION
This solve #183 

![image](https://user-images.githubusercontent.com/63316583/147487993-8697f02f-7d95-4dcd-8506-81a1a5deed05.png)
