### PR TITLE
Fixed FPS not matching in-game cap

### DIFF
--- a/src/main/java/minicraft/core/Initializer.java
+++ b/src/main/java/minicraft/core/Initializer.java
@@ -118,12 +118,6 @@ public class Initializer extends Game {
 				unprocessed--;
 			}
 			
-			try {
-				Thread.sleep(2); // Makes a small pause for 2 milliseconds
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-			}
-			
 			if ((now - lastRender) / 1.0E9 > 1.0 / MAX_FPS) {
 				frames++;
 				lastRender = System.nanoTime();


### PR DESCRIPTION
Does anyone know why there was the 2 millisecond pause in the main game loop? I haven't experienced any issues from removing it and now the game runs perfectly at the fps cap.